### PR TITLE
Fix for Terraform AMI

### DIFF
--- a/resources/example-policies-infrastructure/c7n-101/main.tf
+++ b/resources/example-policies-infrastructure/c7n-101/main.tf
@@ -2,9 +2,25 @@
 provider "aws" {
 }
 
+# AMI to use for EC2 instances
+data "aws_ami" "amazon-linux-2" {
+  most_recent = true
+  owners = ["amazon"]
+  
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+ }
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
 # Creates 3 EC2s with different tagging
 resource "aws_instance" "my-first-policy-pull-stop-not-tagged-ec2" {
-  ami           = "ami-00eb20669e0990cb4"
+  ami           = "${data.aws_ami.amazon-linux-2.id}"
   instance_type = "t2.micro"
   count         = 1
   tags = {
@@ -13,7 +29,8 @@ resource "aws_instance" "my-first-policy-pull-stop-not-tagged-ec2" {
 }
 
 resource "aws_instance" "my-first-policy-pull-stop-tagged-ec2" {
-  ami           = "ami-00eb20669e0990cb4"
+
+  ami           = "${data.aws_ami.amazon-linux-2.id}"
   instance_type = "t2.micro"
   count         = 1
   tags = {
@@ -22,14 +39,13 @@ resource "aws_instance" "my-first-policy-pull-stop-tagged-ec2" {
 }
 
 resource "aws_instance" "my-first-policy-event-stop-tagged-ec2" {
-  ami           = "ami-00eb20669e0990cb4"
+  ami           = "${data.aws_ami.amazon-linux-2.id}"
   instance_type = "t2.micro"
   count         = 1
   tags = {
     "c7n-101" : "my-first-policy-event"
   }
 }
-
 
 # Creates lambda role for event-based policies
 resource "aws_iam_role" "c7n-101-lambda-iam-role" {

--- a/resources/example-policies-infrastructure/c7n-workshop/main.tf
+++ b/resources/example-policies-infrastructure/c7n-workshop/main.tf
@@ -47,9 +47,25 @@ resource "aws_security_group" "c7n-workshop-security-group" {
   }
 }
 
+# AMI to use for EC2 instances
+data "aws_ami" "amazon-linux-2" {
+  most_recent = true
+  owners = ["amazon"]
+  
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+ }
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
 # Creates an EC2
 resource "aws_instance" "c7n-workshop-ec2" {
-  ami           = "ami-00eb20669e0990cb4"
+  ami           = "${data.aws_ami.amazon-linux-2.id}"
   instance_type = "t2.micro"
   count         = 1
 


### PR DESCRIPTION
This PR fixes the AMI issue in Terraform:

- Updates Terraform to search for latest Amaz Linux 2 AMI
- Updates Terraform to use when creating EC2 instances

This PR also:

- Update to README

Tested it all in CloudShell and it works 😸 