### PR TITLE
Configure Terraform cache, specify Makefile shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # project files and directories
 resources/example-policies/c7n-101/policy-execution-output/*
 resources/example-policies/c7n-workshop/policy-execution-output/*
+.terraform-plugin-cache
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # See repo README for more details on Makefile targets
 
+SHELL = /usr/bin/env bash
+
 .PHONY: help
 help: ## Show this help
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[95m%-30s\033[0m %s\n", $$1, $$2}'

--- a/helpers/setup.sh
+++ b/helpers/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# vim: set softtabstop=4 shiftwidth=4 expandtab:
+
 # Text color variables
 PURPLE_BOLD=$'\e[1;95m'
 PURPLE_REGULAR=$'\e[0;95m'
@@ -32,9 +34,28 @@ function aws_cloudshell_install () {
     echo
 }
 
+function configure_terraform_cache () {
+    # Cache Terraform provider files in a common directory, so we
+    # avoid repeat downloads when provisioning multiple sets of
+    # resources.
+
+    if [[ "$USER" == "cloudshell-user" ]]; then
+        # Persistent storage in an AWS CloudShell environment is
+        # limited to 1GB. Keep the Terraform cache in an ephemeral
+        # directory that won't contribute to that limit.
+        export TF_PLUGIN_CACHE_DIR="/tmp/terraform-plugin-cache"
+    else
+        export TF_PLUGIN_CACHE_DIR="$(pwd)/.terraform-plugin-cache"
+    fi
+
+    mkdir -p "$TF_PLUGIN_CACHE_DIR"
+}
+
 
 # Demo infrastructure
 function demo_infra_provision () {
+    configure_terraform_cache
+
     PROJECT="$1"
     
     if [ -z "$PROJECT" ]; then
@@ -87,6 +108,8 @@ function mugc_run () {
 }
 
 function demo_infra_destroy () {
+    configure_terraform_cache
+
     echo
     echo "${PURPLE_REGULAR}Running terraform destroy. See repo ${PURPLE_BOLD}README ${PURPLE_REGULAR}for more details."
     echo


### PR DESCRIPTION
Addresses a couple issues I've encountered running these examples across systems:

* Sets a common [Terraform Provider Plugin Cache](https://www.terraform.io/cli/config/config-file#provider-plugin-cache) location (outside the home directory for AWS CloudShell users, to lessen the risk of running out of space).

* Specifies a shell in the Makefile so things still work outside of bash.